### PR TITLE
Support Provisioning MySQL Databases

### DIFF
--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -267,3 +267,17 @@ type Property struct {
 	Value       string `json:"value"`
 	Description string `json:"description"`
 }
+
+// +kubebuilder:object:generate:=false
+type DatabaseActionArgs interface {
+	GetActionArguments() []ActionArgument
+}
+
+// +kubebuilder:object:generate:=false
+type PostgresActionArgs struct{}
+
+// +kubebuilder:object:generate:=false
+type MongodbActionArgs struct{}
+
+// +kubebuilder:object:generate:=false
+type MysqlActionArgs struct{}


### PR DESCRIPTION
**What this PR does / why we need it**:  
Allows provisioning of MySQL databases using the operator. This is done using new database types which dynamically set the action arguments based on the name of the database in the config file. 

**How Has This Been Tested?**:
Added new test cases which assert the generation of the correct action arguments based on the database name. Also confirmed successful provisioning of database using test drive.

**Release note**:
```release-note
NONE
```