### PR TITLE
Defaulted db_user to admin in MongoDB provisioning

### DIFF
--- a/api/v1alpha1/ndb_api_helpers.go
+++ b/api/v1alpha1/ndb_api_helpers.go
@@ -259,7 +259,7 @@ func GetActionArgumentsByDatabaseType(databaseType string) (DatabaseActionArgs, 
 	case DATABASE_TYPE_MONGODB:
 		dbTypeActionArgs = &MongodbActionArgs{}
 	default:
-		return nil, errors.New("Invalid Database Type: supported values: mysql, postgres, mongodb")
+		return nil, errors.New("invalid database type: supported values: mysql, postgres, mongodb")
 	}
 	return dbTypeActionArgs, nil
 }
@@ -326,7 +326,7 @@ func (m *MongodbActionArgs) GetActionArguments(dbSpec DatabaseSpec) []ActionArgu
 		},
 		{
 			Name:  "db_user",
-			Value: dbSpec.Instance.DatabaseInstanceName,
+			Value: "admin",
 		},
 		{
 			Name:  "backup_policy",

--- a/test/ndb_api_helpers_test.go
+++ b/test/ndb_api_helpers_test.go
@@ -653,7 +653,7 @@ func TestGetActionArgumentsByDatabaseType(t *testing.T) {
 		{Name: "journal_size", Value: "100"},
 		{Name: "restart_mongod", Value: "true"},
 		{Name: "working_dir", Value: "/tmp"},
-		{Name: "db_user", Value: "test"},
+		{Name: "db_user", Value: "admin"},
 		{Name: "backup_policy", Value: "primary_only"},
 	}
 	if !reflect.DeepEqual(mongodbArgs.GetActionArguments(v1alpha1.DatabaseSpec{Instance: v1alpha1.Instance{DatabaseInstanceName: "test"}}), expectedMongodbArgs) {


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR addresses a bug which assigns the vm instance name to the db_user in mongodb provisioning.

**How Has This Been Tested?**:
This has been tested manually. 
I created a db instance of mongodb type (with service creation hack, since that is also a known bug at the time of writing this).
I also created an application pod with details about the service and credentials. (https://github.com/nutanix-scratch/manavrajvanshi/tree/main/best-app/mongodb)
I was able to interact with the application via postman when the database was provisioned.

<img width="693" alt="image" src="https://github.com/nutanix-cloud-native/ndb-operator/assets/107612534/3216c8ad-9e58-45ad-8af6-bfeace8aca5c">
<img width="693" alt="image" src="https://github.com/nutanix-cloud-native/ndb-operator/assets/107612534/a751f402-cd53-4259-a3e9-5426a034f80b">




**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```