### PR TITLE
Fix gh-actions for testing container build

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-binary:
+    name: Build Binary
     runs-on: ubuntu-latest
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -32,17 +33,15 @@ jobs:
           exit-code: "1"
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
-  build_container:
+  build-container:
     name: Build Container
     runs-on: ubuntu-latest
     steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "^1.17"
 
       - name: Build container
         env:

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   build-binary:
-    name: Build Binary
     runs-on: ubuntu-latest
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -34,7 +33,6 @@ jobs:
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
   build-container:
-    name: Build Container
     runs-on: ubuntu-latest
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  build-container:
+  build-binary:
     runs-on: ubuntu-latest
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -32,3 +32,19 @@ jobs:
           exit-code: "1"
           vuln-type: "os,library"
           severity: "CRITICAL,HIGH"
+  build_container:
+    name: Build Container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "^1.17"
+
+      - name: Build container
+        env:
+          IMAGE_TAG_BASE: ${{ github.repository }}_build_container_test
+        run: make docker-build

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Build container
+      - name: Build container image
         env:
           IMAGE_TAG_BASE: ${{ github.repository }}_build_container_test
         run: make docker-build


### PR DESCRIPTION
**What this PR does / why we need it**:
The github actions do not cover the container build step. This PR adds the github action to test a container build for the changes in the push and pull_requests. As an example, the container-build for #102 should ideally fail but it passes due to the missing step.

**How Has This Been Tested?**:
This has been tested by pushing changes to a branch and verifying that the `Build Container` test step is executed.

Release Notes:
```release-note
NONE
```