### PR TITLE
Release v0.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.8)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.8)
-VERSION ?= 0.5.0
+VERSION ?= 0.5.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/nutanix-cloud-native/ndb-operator/controller
-  newTag: v0.5.0
+  newTag: v0.5.1


### PR DESCRIPTION
Bumped kube-rbac-proxy to v0.15.0 to fix security vulnerability.