### PR TITLE
Release v0.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.8)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.8)
-VERSION ?= 0.5.0
+VERSION ?= 0.5.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.8)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.8)
-VERSION ?= 0.5.2
+VERSION ?= 0.5.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/nutanix-cloud-native/ndb-operator/controller
-  newTag: v0.5.2
+  newTag: v0.5.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/nutanix-cloud-native/ndb-operator/controller
-  newTag: v0.5.0
+  newTag: v0.5.2


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the operator version from `v0.5.0` to `v0.5.1`. 

**Helm Before:**
![image](https://github.com/nutanix-cloud-native/ndb-operator/assets/54862675/4ee81a25-d2f4-470b-9d59-4bc2c1cdaf15)

**Helm After:**
![image](https://github.com/nutanix-cloud-native/ndb-operator/assets/54862675/0571fd35-5006-4226-b4c7-f4971cc08fa1)

**How Has This Been Tested?**:
`make run-automation-provisioning`
[pg-provisioning-si_test.txt](https://github.com/nutanix-cloud-native/ndb-operator/files/14964670/pg-provision.txt) (successful)
[mysql-provisioning-si_test](https://github.com/nutanix-cloud-native/ndb-operator/files/14964671/mysql-provision.txt) (successful)
[mongo-provisioning-si_test](https://github.com/nutanix-cloud-native/ndb-operator/files/14969401/mongo-provision.txt) (The client VM for this operation has been powered off)
mssql-provisioning-si_test:
![image](https://github.com/nutanix-cloud-native/ndb-operator/assets/54862675/2afa0cbd-1c86-45f8-9743-3e72e1c08954)

`make run-automation-cloning`
[mssql-cloning-si_test.txt](https://github.com/nutanix-cloud-native/ndb-operator/files/15017491/mssql-cloning-si_test.txt)
![image](https://github.com/nutanix-cloud-native/ndb-operator/assets/54862675/bc0bb2a8-3f11-4e5a-8cc5-40772efdb62b)

`make test-coverage`
<img width="1115" alt="image" src="https://github.com/nutanix-cloud-native/ndb-operator/assets/54862675/a74684ba-a605-447b-8bf0-d2bba83a0b3c">

**Release note**:

```release-note
1. Bumped up go version in go.mod and workflows from 1.20 to 1.21.7.
2. Bumped up kube-rbac-proxy version from v0.15.0 to v0.16.0.
3. Removed samples folder reference which was located in config/manifests/kustomization.
4. Fixed static lint errors
5. Increased unit test coverage to 78%.
6. Add a new makefile target to give coverage numbers
7. Introduced an interface for the rest client - NDBClientHTTPInterface to mock the responses from NDB instead of spinning up a new http server for every test. 
8. Added E2E additional logging for setting up log environment failure case.
