### PR TITLE
Bumped kube-rbac-proxy from v0.16.0 to v0.17.0

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.17.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumped kube-rbac-proxy from v0.16.0 to v0.17.0 to fix security vulnerabilities

**How Has This Been Tested?**:
n/a
