### PR TITLE
add CVE fixes using go 1.25.8

### DIFF
--- a/.github/workflows/blackduck-intelligent-scan.yaml
+++ b/.github/workflows/blackduck-intelligent-scan.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Build Project
         run: make build

--- a/.github/workflows/blackduck-policy-check.yaml
+++ b/.github/workflows/blackduck-policy-check.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Build Project
         run: make build

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Test build
         run: make test build
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Build container image
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Install tools
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
 
       - name: Build Project
         run: make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.7 AS builder
+FROM golang:1.25.8 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: quay.io/brancz/kube-rbac-proxy:v0.21.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.21.2
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nutanix-cloud-native/ndb-operator
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION


**Release note**:

1. rollout go 1.25.8 version
2. Use kube-rbac-proxy image 0.21.2
