### PR TITLE
remove reference of gh-pages

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,1 +1,0 @@
-charts-dir: deploy

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,20 +1,20 @@
 name: Release Charts
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Linting Charts"]
     branches:
       - main
-    paths:
-      - 'deploy/helm/**'
-      - '.github/workflows/helm-release.yaml'
-  workflow_dispatch:  # manual re-run to publish after fixing release config
+    types:
+      - completed
+  workflow_dispatch:  # manual re-run without a preceding lint run
 
 permissions:
-  contents: write
   packages: write
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,18 +22,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Install Helm
         uses: jdx/mise-action@v3
         with:
           tool_versions: |
             helm: latest
+
       - name: Package chart
-        run: helm package deploy/helm --destination .cr-release-packages   
+        run: helm package deploy/helm --destination .cr-release-packages
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -54,4 +50,3 @@ jobs:
               helm push "$pkg" oci://ghcr.io/nutanix-cloud-native/chart
             fi
           done
-          

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -32,18 +32,8 @@ jobs:
         with:
           tool_versions: |
             helm: latest
-
-      # charts_dir must match .github/cr.yaml (charts-dir: deploy). Default "charts" finds nothing here.
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
-        with:
-          charts_dir: deploy
-          config: .github/cr.yaml
-          skip_existing: true
-          skip_upload: true
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          
+      - name: Package chart
+        run: helm package deploy/helm --destination .cr-release-packages   
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -54,6 +44,11 @@ jobs:
 
       - name: Push charts to GHCR
         run: |
+          VERSION=$(helm show chart deploy/helm | grep '^version:' | awk '{print $2}')
+          if helm show chart oci://ghcr.io/nutanix-cloud-native/chart/ndb-operator --version "$VERSION" 2>/dev/null | grep -q "^version:"; then
+            echo "Chart $VERSION already exists on GHCR, skipping push."
+            exit 0
+          fi
           for pkg in .cr-release-packages/*.tgz; do
             if [ -f "$pkg" ]; then
               helm push "$pkg" oci://ghcr.io/nutanix-cloud-native/chart

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -40,6 +40,7 @@ jobs:
           charts_dir: deploy
           config: .github/cr.yaml
           skip_existing: true
+          skip_upload: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -45,8 +45,4 @@ jobs:
             echo "Chart $VERSION already exists on GHCR, skipping push."
             exit 0
           fi
-          for pkg in .cr-release-packages/*.tgz; do
-            if [ -f "$pkg" ]; then
-              helm push "$pkg" oci://ghcr.io/nutanix-cloud-native/chart
-            fi
-          done
+          helm push .cr-release-packages/ndb-operator-${VERSION}.tgz oci://ghcr.io/nutanix-cloud-native/chart


### PR DESCRIPTION
Small fix for removing reference of gh-pages branch in helm github workflows.
- remove chart-release action and directly package and push the tgz file.
- before pushing tgz file, check if version is alrady present in OCI registry.
- make helm release job dependent on lint chart job in main branch.
