### PR TITLE
Fixe Helm registry authentication

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -32,11 +32,10 @@ jobs:
         run: helm package deploy/helm --destination .cr-release-packages
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            --username ${{ github.actor }} \
+            --password-stdin
 
       - name: Push charts to GHCR
         run: |


### PR DESCRIPTION
Release notes:
- GHCR.io OCI registry authentication by using helm registry login command instead of docker login action.

this is tested using  in different branch - [link](https://github.com/nutanix-cloud-native/ndb-operator/actions/runs/23946651634)