### PR TITLE
CVE fixes

### DIFF
--- a/.github/workflows/blackduck-intelligent-scan.yaml
+++ b/.github/workflows/blackduck-intelligent-scan.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.26.2"
 
       - name: Build Project
         run: make build

--- a/.github/workflows/blackduck-policy-check.yaml
+++ b/.github/workflows/blackduck-policy-check.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.26.2"
 
       - name: Build Project
         run: make build

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.26.2"
 
       - name: Test build
         run: make test build
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.26.2"
 
       - name: Build container image
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.26.2"
 
       - name: Install tools
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.8"
+          go-version: "1.26.2"
 
       - name: Build Project
         run: make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.8 AS builder
+FROM golang:1.26.2 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: quay.io/brancz/kube-rbac-proxy:v0.21.2
+          image: quay.io/brancz/kube-rbac-proxy:v0.22.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nutanix-cloud-native/ndb-operator
 
-go 1.25.8
+go 1.26.2
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
CVE fixes:
- upgraded go version to 1.26.2.
- upgraded k8s dependencies to 1.35+ version for k8s clusters (backward compatible till 1.33).
- upgraded kube-rbac-proxy image to 0.22.0.
