### PR TITLE
ERA-65454: CVE fixes

### DIFF
--- a/.github/workflows/blackduck-intelligent-scan.yaml
+++ b/.github/workflows/blackduck-intelligent-scan.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Build Project
         run: make build

--- a/.github/workflows/blackduck-policy-check.yaml
+++ b/.github/workflows/blackduck-policy-check.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Build Project
         run: make build

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Test build
         run: make test build
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Build container image
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Install tools
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: Build Project
         run: make build

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.26.3 AS builder
 
 ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
             capabilities:
               drop:
                 - "ALL"
-          image: quay.io/brancz/kube-rbac-proxy:v0.22.0
+          image: docker.io/bitnami/kube-rbac-proxy@sha256:4bfaad756b23b5f4c11c66716b72b45a369baad988fbe3c3cf3f0446e3c86fea
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nutanix-cloud-native/ndb-operator
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## upgrade to go 1.26.3 to find below CVEs:
CVE-2026-33811
CVE-2026-33814
CVE-2026-39820
CVE-2026-39836
CVE-2026-42499
CVE-2026-39823
CVE-2026-39826
CVE-2026-39825

kube-rbac-proxy version used
<img width="1234" height="50" alt="Screenshot 2026-05-28 at 9 33 57 AM" src="https://github.com/user-attachments/assets/f7c24a4b-8218-4704-b6c0-bccfd67dc6d1" />

### testing & verification:
<img width="1056" height="489" alt="Screenshot 2026-05-27 at 8 25 54 PM" src="https://github.com/user-attachments/assets/331eb13e-f4b7-4b15-a23e-553590de59d8" />
