### PR TITLE
helm release  for Opreator 0.5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ spec:
     #   ...
 ```
 
-### Example Defaults ConfigMap for Postgres HA
+### Example Defaults ConfigMap for HA instances
 The `defaultsConfigMapRef` field on the Database CR points to a ConfigMap that pre-fills profiles and time machine settings, reducing repetition across CRs. Keys are prefixed with the database `type` value (`postgres.`, `mysql.`) so a single ConfigMap can hold defaults for multiple engines.
 ```
 apiVersion: v1

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ndb-operator
 description: A Helm chart for Nutanix Database Kubernetes Operator
 type: application
-version: 0.5.8
-appVersion: v0.5.5
+version: 0.5.9
+appVersion: v0.5.6
 maintainers:
   - name: mazin-s
     email: mazin.shaaeldin@nutanix.com
@@ -23,13 +23,13 @@ icon: https://www.nutanix.com/content/dam/nutanix/global/icons/products/svg/Nuta
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Chart 0.5.8: Add support for Postgres HA and Oracle SI."
+      description: "Add MySQL HA"
     - kind: changed
-      description: "Chart 0.5.8: controller image v0.5.5."
+      description: "Chart 0.5.9: controller image v0.5.6."
     - kind: security
-      description: "kube-rbac-proxy v0.22.0 (quay.io/brancz/kube-rbac-proxy)."
+      description: "upgraded go verion to 1.26.3, kube-rbac-proxy v0.22.0 docker.io/bitnami/kube-rbac-proxy"
     - kind: changed
-      description: "Release details: https://github.com/nutanix-cloud-native/ndb-operator/releases/tag/v0.5.5"
+      description: "Release details: https://github.com/nutanix-cloud-native/ndb-operator/releases/tag/v0.5.6"
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/license: Apache-2.0
   artifacthub.io/maintainers: |

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -432,64 +432,104 @@ spec:
 ```
 
 
-#### Creating Postgres HA instance resource
-```yaml
+### Creating HA instance resource (Postgres, MySQL)
+The `haConfig` block is engine-specific. Use `type: postgres` with a `haConfig.postgres` sub-block, or `type: mysql` with a `haConfig.mysql` sub-block. The `nodes` array, `timeMachine`, and `profiles` fields are shared across both engines.
+
+**Postgres HA** — HAProxy VMs provide load balancing. Applications connect to **HAProxy VM IPs** on port 5000 (read-write) and 5001 (read-only).
+
+**MySQL HA (router disabled)** — Applications connect directly to the **Master VM** on port 3306 (read-write). The read-only service targets all **Replica VM** IPs. 
+
+**MySQL HA (router enabled)** — MySQL Router VMs handle load balancing. Applications connect to **Router VM IPs** on port 6446 (read-write) and 6447 (read-only).
+
+NOTE: the ports mentioned are default ports and can be overridden.
+
+```
 apiVersion: ndb.nutanix.com/v1alpha1
 kind: Database
 metadata:
-  name: Postgres-HA-K8s-resource
+  name: ha-k8s-resource
   namespace: default
 spec:
   ndbRef: ndbserver
+  # defaultsConfigMapRef: <ha-defaults-cm>   # injects timezone, profiles, timeMachine from ConfigMap
   databaseInstance:
-    name: "PGHA_instance_DB"
-    description: "Postgres HA instance"
-    # defaultsConfigMapRef: pgha-defaults   # injects timezone, profiles, timeMachine from ConfigMap
-    type: postgres
-    credentialSecret: pgha-db-secret
+    name: "HA_instance_DB"
+    description: "HA instance"
+    type: postgres        # ── or: mysql
+    credentialSecret: db-secret
     size: 200
-    clusterName: "<PE cluster name (as shown in NDB UI)>" # This is often the Primary PE cluster
-    # ClusterID: "UUID of the PE cluster"
+    clusterName: "<PE cluster name (as shown in NDB UI)>"   # primary PE cluster
+    # clusterId: "<UUID of the PE cluster>"
     databaseNames:
-      - PGHA_instance
-    timeMachine:
-      name: "PGHA_TM"
-      description: "TM for Postgres HA"
+      - ha_db
+    # timeMachine: # use timemachine section here to explicitly define and override defaults configmap
+    #   ...
+    # profiles: # use profiles section here to explicitly define and override defaults configmap
+    #   ....
     haConfig:
-      patroniClusterName: "pgha-patroni" # any desired name
-      clusterName: "PGHA_cluster" # any desired name
-      enableSynchronousMode: true # default is false, This is for data replication across DB nodes
-      # provisionVirtualIP: true # default is false, keep this true if having stretched VLAN and need to provision VirtualIP
-      # writePort: 5000   # defaults to 5000 if omitted
-      # readPort: 5001    # defaults to 5001 if omitted
+      clusterName: "HA_cluster"          # any desired name
+      enableSynchronousMode: true        # default: false; enables synchronous replication (Postgres only)
+
+      # ── Postgres-specific ──────────────────────────────────────────────────
+      postgres:
+        patroniClusterName: "ha-patroni" # any desired name
+        # provisionVirtualIP: true       # default: false; set true for stretched VLANs
+        # writePort: 5000                # HAProxy write port; defaults to 5000
+        # readPort: 5001                 # HAProxy read port; defaults to 5001
+
+      # ── MySQL-specific ─────────────────────────────────────────────────────
+      # mysql:
+      #   innoDBClusterName: "ha-innodb" # any desired name
+      #   deployMySQLRouter: false       # set true to add MySQL Router nodes (see nodes below)
+      #   # mysqlClusterUsername: mysqladmin   # default: mysqladmin
+      #   # replicationUser: repl             # default: repl
+      #   # routerRWPort: 6446               # only used when deployMySQLRouter: true; default: 6446
+      #   # routerROPort: 6447               # only used when deployMySQLRouter: true; default: 6447
+
       nodes:
-        - vmName: "PGHA_haproxy1" # any desired name
+        # ── Postgres: HAProxy nodes (required) ──
+        - vmName: "HA_haproxy1"
           nodeType: "haproxy"
           clusterName: "<PE cluster name (as shown in NDB UI)>"
-          # clusterId: "UUID of the PE cluster"
-        - vmName: "PGHA_haproxy2" # any desired name
+        - vmName: "HA_haproxy2"
           nodeType: "haproxy"
           clusterName: "<PE cluster name (as shown in NDB UI)>"
-          # clusterId: "UUID of the PE cluster"
-        - vmName: "PGHA_DB-1" # any desired name
+
+        # ── Postgres: database nodes ──
+        - vmName: "HA_DB-1"
           nodeType: "database"
-          role: "Primary"
+          role: "Primary"            # Postgres: Primary | MySQL: Master
           clusterName: "<PE cluster name (as shown in NDB UI)>"
-          # clusterId: "UUID of the PE cluster"
-        - vmName: "PGHA_DB-2" # any desired name
+        - vmName: "HA_DB-2"
+          nodeType: "database"
+          role: "Secondary"          # Postgres: Secondary | MySQL: Replica
+          clusterName: "<PE cluster name (as shown in NDB UI)>"
+        - vmName: "HA_DB-3"
           nodeType: "database"
           role: "Secondary"
-          clusterName: "<PE cluster name (as shown in NDB UI)>"
-          # clusterId: "UUID of the PE cluster"
-        - vmName: "PGHA_DB-3" # any desired name
-          nodeType: "database"
-          role: "Secondary"
-          clusterName: "<PE cluster name (as shown in NDB UI)>"
-          # clusterId: "UUID of the PE cluster"
+          clusterName: "<PE cluster name (as shown in NDB UI)>"  # can be a different PE cluster
+
+        # ── MySQL router-enabled only: add mysqlrouter nodes ──
+        # - vmName: "HA_mysqlrouter1"
+        #   nodeType: "mysqlrouter"
+        #   clusterName: "<PE cluster name (as shown in NDB UI)>"
+        # - vmName: "HA_mysqlrouter2"
+        #   nodeType: "mysqlrouter"
+        #   clusterName: "<PE cluster name (as shown in NDB UI)>"
+
+    # ── additionalArguments ────────────────────────────────────────────────
+    # Postgres supports: listener_port only
+    # MySQL supports: listener_port, allocate_mysql_hugepage, ensure_vm_host_distribution,
+    #                 replication_user, replication_password, mysql_cluster_username,
+    #                 mysql_cluster_password, innodb_cluster_name, cluster_name,
+    #                 deploy_mysqlrouter, router_rw_port, router_ro_port
+    # additionalArguments:
+    #   ...
 ```
 
-### Example Defaults configmap for HA instance
-```yaml
+### Example Defaults ConfigMap for HA instances
+The `defaultsConfigMapRef` field on the Database CR points to a ConfigMap that pre-fills profiles and time machine settings, reducing repetition across CRs. Keys are prefixed with the database `type` value (`postgres.`, `mysql.`) so a single ConfigMap can hold defaults for multiple engines.
+```
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -498,7 +538,7 @@ metadata:
 data:
   timezone: "UTC"
   # postgres-prefixed keys take priority over unprefixed keys for postgres databases
-  postgres.profiles.software.name: "POSTGRES_15.6_HA_ENABLED_ROCKY_LINUX_8_OOB"
+  postgres.profiles.software.name: "POSTGRES_15.6_HA_ENABLED_ROCKY_LINUX_8_OOB" # or use mysql.profiles....
   postgres.profiles.compute.name: "DEFAULT_HA_COMPUTE"
   postgres.profiles.network.name: "PGHA_VLAN"
   postgres.profiles.dbParam.name: "DEFAULT_POSTGRES_HA_PARAMS"

--- a/deploy/helm/crds/customresourcedefinition-databases.ndb.nutanix.com.yaml
+++ b/deploy/helm/crds/customresourcedefinition-databases.ndb.nutanix.com.yaml
@@ -201,6 +201,46 @@ spec:
                       enableSynchronousMode:
                         description: Enable synchronous replication mode
                         type: boolean
+                      mysql:
+                        description: |-
+                          MySQL contains InnoDB Cluster and MySQL Router settings specific to MySQL HA.
+                          Required when the database type is "mysql".
+                        properties:
+                          deployMySQLRouter:
+                            description: |-
+                              DeployMySQLRouter controls whether MySQL Router VMs are provisioned for load balancing.
+                              When true, Router VMs must be included in nodes[] with nodeType "mysqlrouter",
+                              When false, applications connect directly to the Master VM on port 3306.
+                            type: boolean
+                          innoDBClusterName:
+                            description: Name used by MySQL InnoDB Cluster for internal
+                              cluster coordination
+                            type: string
+                          mysqlClusterUsername:
+                            description: MySQLClusterUsername is the admin user for
+                              InnoDB Cluster management. Defaults to "mysqladmin".
+                            type: string
+                          replicationUser:
+                            description: ReplicationUser is the user for group replication.
+                              Defaults to "repl".
+                            type: string
+                          routerROPort:
+                            default: 6447
+                            description: |-
+                              RouterROPort is the MySQL Router read-only port. Defaults to 6447.
+                              Only meaningful when DeployMySQLRouter is true.
+                            format: int32
+                            type: integer
+                          routerRWPort:
+                            default: 6446
+                            description: |-
+                              RouterRWPort is the MySQL Router read-write port. Defaults to 6446.
+                              Only meaningful when DeployMySQLRouter is true.
+                            format: int32
+                            type: integer
+                        required:
+                        - innoDBClusterName
+                        type: object
                       nodes:
                         description: Node placement and role definitions for all VMs
                           in the HA cluster
@@ -223,10 +263,12 @@ spec:
                                 "Automatic")
                               type: string
                             nodeType:
-                              description: 'Type of this node: "haproxy" or "database"'
+                              description: 'Type of this node: "database", "haproxy"
+                                (Postgres HA), or "mysqlrouter" (MySQL HA)'
                               enum:
                               - haproxy
                               - database
+                              - mysqlrouter
                               type: string
                             role:
                               description: 'Role of this node (database nodes only):

--- a/deploy/helm/templates/deployment-ndb-operator-controller-manager.yaml
+++ b/deploy/helm/templates/deployment-ndb-operator-controller-manager.yaml
@@ -59,7 +59,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: quay.io/brancz/kube-rbac-proxy:v0.22.0
+        image: docker.io/bitnami/kube-rbac-proxy@sha256:4bfaad756b23b5f4c11c66716b72b45a369baad988fbe3c3cf3f0446e3c86fea
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
### Helm release notes:
- Support for MySQL HA (router enabled/disabled workflow)
- Go version upgraded to 1.26.3
- Switched to bitnami/kube-rbac-proxy registry inplace of quay.io/brancz/kube-rbac-proxy (for security hardened images)

### Tests/Verifications:
<img width="651" height="259" alt="Screenshot 2026-05-28 at 12 51 13 PM" src="https://github.com/user-attachments/assets/9fbdefa5-8c8e-4a15-b087-5a2905979c37" />
<img width="885" height="369" alt="Screenshot 2026-05-28 at 12 51 42 PM" src="https://github.com/user-attachments/assets/f722d2ac-59f9-40b6-9b0d-8adee932e2ce" />

