### PR TITLE
new helm release

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -40,9 +40,8 @@ jobs:
       - name: Push charts to GHCR
         run: |
           VERSION=$(helm show chart deploy/helm | grep '^version:' | awk '{print $2}')
-          # TODO: Uncomment before next release (this is temporary fix)
-          # if helm show chart oci://ghcr.io/nutanix-cloud-native/chart/ndb-operator --version "$VERSION" 2>/dev/null | grep -q "^version:"; then
-          #   echo "Chart $VERSION already exists on GHCR, skipping push."
-          #   exit 0
-          # fi
+          if helm show chart oci://ghcr.io/nutanix-cloud-native/chart/ndb-operator --version "$VERSION" 2>/dev/null | grep -q "^version:"; then
+            echo "Chart $VERSION already exists on GHCR, skipping push."
+            exit 0
+          fi
           helm push .cr-release-packages/ndb-operator-${VERSION}.tgz oci://ghcr.io/nutanix-cloud-native/chart

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ndb-operator
 description: A Helm chart for Nutanix Database Kubernetes Operator
 type: application
-version: 0.5.9
-appVersion: v0.5.6
+version: 0.5.10
+appVersion: v0.5.7
 maintainers:
   - name: mazin-s
     email: mazin.shaaeldin@nutanix.com
@@ -22,12 +22,10 @@ maintainers:
 icon: https://www.nutanix.com/content/dam/nutanix/global/icons/products/svg/Nutanix-Era-40.svg
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Add MySQL HA"
     - kind: changed
-      description: "Chart 0.5.9: controller image v0.5.6."
+      description: "Chart 0.5.10: controller image v0.5.7."
     - kind: security
-      description: "upgraded go verion to 1.26.3, kube-rbac-proxy v0.22.0 docker.io/bitnami/kube-rbac-proxy"
+      description: "upgraded go verion to 1.26.5, kube-rbac-proxy v0.22.1 docker.io/bitnami/kube-rbac-proxy"
     - kind: changed
       description: "Release details: https://github.com/nutanix-cloud-native/ndb-operator/releases/tag/v0.5.6"
   artifacthub.io/containsSecurityUpdates: "true"

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -20,39 +20,7 @@ NDB operator supports these functionalities:
 
 ## Installation and Running on the cluster
 
-### Method 1: Install from Helm Repository (Recommended)
-
-Add the Nutanix Helm repository:
-
-```sh
-helm repo add nutanix https://nutanix.github.io/helm/
-helm repo update
-```
-
-Install the latest version:
-
-```sh
-helm install ndb-operator nutanix/ndb-operator \
-  --namespace ndb-operator-system \
-  --create-namespace
-```
-
-Install a specific version:
-
-```sh
-helm install ndb-operator nutanix/ndb-operator \
-  --version 0.5.9 \
-  --namespace ndb-operator-system \
-  --create-namespace
-```
-
-List available versions:
-
-```sh
-helm search repo nutanix/ndb-operator --versions
-```
-
-### Method 2: Install from OCI Registry (GHCR)
+### Install from OCI Registry (GHCR)
 
 Install the latest version:
 
@@ -66,7 +34,7 @@ Install a specific version:
 
 ```sh
 helm install ndb-operator oci://ghcr.io/nutanix-cloud-native/chart/ndb-operator \
-  --version 0.5.9 \
+  --version 0.5.10 \
   --namespace ndb-operator-system \
   --create-namespace
 ```
@@ -101,14 +69,9 @@ kubectl get crds | grep ndb.nutanix.com
 To upgrade to a newer version:
 
 ```sh
-# Using Helm repository
-helm repo update
-helm upgrade ndb-operator nutanix/ndb-operator \
-  --namespace ndb-operator-system
-
 # Using OCI registry
 helm upgrade ndb-operator oci://ghcr.io/nutanix-cloud-native/chart/ndb-operator \
-  --version 0.5.9 \
+  --version 0.5.10 \
   --namespace ndb-operator-system
 ```
 

--- a/deploy/helm/templates/deployment-ndb-operator-controller-manager.yaml
+++ b/deploy/helm/templates/deployment-ndb-operator-controller-manager.yaml
@@ -59,7 +59,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: docker.io/bitnami/kube-rbac-proxy@sha256:4bfaad756b23b5f4c11c66716b72b45a369baad988fbe3c3cf3f0446e3c86fea
+        image: docker.io/bitnami/kube-rbac-proxy@sha256:b7e25b5c57d9b3bfaabf4a9aa173d126344698d097ac44b943096dbe7a21fc05
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Release notes:

- fix CVEs and upgrade to go version 1.26.5
- supports kubernetes cluster version 1.35+ 